### PR TITLE
Change check 2.7 type to "warn" in case the check is failed.

### DIFF
--- a/cfg/17.06/definitions.yaml
+++ b/cfg/17.06/definitions.yaml
@@ -329,6 +329,7 @@ groups:
   - id: 2.7
     description: "Ensure the default ulimit is configured appropriately (Not Scored)"
     audit: ps -ef | grep dockerd
+    type: manual
     tests:
       test_items:
       - flag: "--default-ulimit"


### PR DESCRIPTION
During CIS scan, if the check 2,7 fails it needs to be shown as "warn" and not as "fail".
@jerbia 