### PR TITLE
When the chosen docker version is not specified, default version will be chosen (17.06)

### DIFF
--- a/app.go
+++ b/app.go
@@ -16,7 +16,6 @@ import (
 func app(cmd *cobra.Command, args []string) {
 	var version string
 	var err error
-	defaultVersion := "17.06"
 
 	// Get version of Docker benchmark to run
 	if dockerVersion != "" {
@@ -32,12 +31,7 @@ func app(cmd *cobra.Command, args []string) {
 
 	path, err := getDefinitionFilePath(version)
 	if err != nil {
-		fmt.Printf("Failed to find configuration for version %sUsing default configuration - version %s",
-			version, defaultVersion)
-		path, err = getDefinitionFilePath(defaultVersion)
-		if err != nil {
-			util.ExitWithError(err)
-		}
+		util.ExitWithError(err)
 	}
 
 	controls, err := getControls(path)

--- a/app.go
+++ b/app.go
@@ -16,6 +16,7 @@ import (
 func app(cmd *cobra.Command, args []string) {
 	var version string
 	var err error
+	defaultVersion := "17.06"
 
 	// Get version of Docker benchmark to run
 	if dockerVersion != "" {
@@ -31,7 +32,12 @@ func app(cmd *cobra.Command, args []string) {
 
 	path, err := getDefinitionFilePath(version)
 	if err != nil {
-		util.ExitWithError(err)
+		fmt.Printf("Failed to find configuration for version %sUsing default configuration - version %s",
+			version, defaultVersion)
+		path, err = getDefinitionFilePath(defaultVersion)
+		if err != nil {
+			util.ExitWithError(err)
+		}
 	}
 
 	controls, err := getControls(path)

--- a/root.go
+++ b/root.go
@@ -25,17 +25,16 @@ import (
 )
 
 var (
-	cfgDir        = "cfg"
-	dockerVersion = "17.06"
-
 	noResults      bool
 	noSummary      bool
 	noRemediations bool
 
-	cfgFile   string
-	checkList string
-	name      string
-	jsonFmt   bool
+	dockerVersion string
+	cfgDir        string
+	cfgFile       string
+	checkList     string
+	name          string
+	jsonFmt       bool
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -71,7 +70,7 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&noResults, "noresults", false, "Disable printing of results section")
 	RootCmd.PersistentFlags().BoolVar(&noSummary, "nosummary", false, "Disable printing of summary section")
 	RootCmd.PersistentFlags().BoolVar(&noRemediations, "noremediations", false, "Disable printing of remediations section")
-	RootCmd.Flags().StringVarP(&dockerVersion, "version", "", "", "Specify Docker version, automatically detected if unset")
+	RootCmd.Flags().StringVarP(&dockerVersion, "version", "", "17.06", "Specify Docker version, automatically detected if unset")
 	RootCmd.Flags().StringVarP(&cfgDir, "config-dir", "D", "cfg", "directory to get benchmark definitions")
 	RootCmd.PersistentFlags().BoolVar(&jsonFmt, "json", false, "Prints the results as JSON")
 	RootCmd.PersistentFlags().StringVarP(


### PR DESCRIPTION
Default version is 17.06.
For example, I'm running docker 18.06 and not specifying --version, It will run the yaml
file in cfg/17.06