### PR TITLE
Fixed printing output with noRemidiations flag

### DIFF
--- a/app.go
+++ b/app.go
@@ -56,7 +56,7 @@ func outputResults(controls *check.Controls, summary check.Summary) error {
 		}
 		fmt.Println(string(out))
 	} else {
-		util.PrettyPrint(controls, summary)
+		util.PrettyPrint(controls, summary, noRemediations)
 	}
 
 	return nil


### PR DESCRIPTION
When flag --noremediations is set, the program will print the output without the remediation.