### PR TITLE
Added includeTestOutput attribute

### DIFF
--- a/app.go
+++ b/app.go
@@ -56,7 +56,7 @@ func outputResults(controls *check.Controls, summary check.Summary) error {
 		}
 		fmt.Println(string(out))
 	} else {
-		util.PrettyPrint(controls, summary, noRemediations)
+		util.PrettyPrint(controls, summary, noRemediations, includeTestOutput)
 	}
 
 	return nil

--- a/root.go
+++ b/root.go
@@ -29,12 +29,13 @@ var (
 	noSummary      bool
 	noRemediations bool
 
-	dockerVersion string
-	cfgDir        string
-	cfgFile       string
-	checkList     string
-	name          string
-	jsonFmt       bool
+	dockerVersion     string
+	cfgDir            string
+	cfgFile           string
+	checkList         string
+	name              string
+	jsonFmt           bool
+	includeTestOutput bool
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -73,6 +74,7 @@ func init() {
 	RootCmd.Flags().StringVarP(&dockerVersion, "version", "", "17.06", "Specify Docker version, automatically detected if unset")
 	RootCmd.Flags().StringVarP(&cfgDir, "config-dir", "D", "cfg", "directory to get benchmark definitions")
 	RootCmd.PersistentFlags().BoolVar(&jsonFmt, "json", false, "Prints the results as JSON")
+	RootCmd.PersistentFlags().BoolVar(&includeTestOutput, "include-test-output", false, "Prints the test's output")
 	RootCmd.PersistentFlags().StringVarP(
 		&checkList,
 		"check",


### PR DESCRIPTION
Prints the result that returned from the test audit command.

NOTICE!
In order to make this feature work, The corresponding branch in "Bench-common" has to be merged in the same time.