### PR TITLE
check if DockerRootDir is really mounted

### DIFF
--- a/cfg/1.13.0/definitions.yaml
+++ b/cfg/1.13.0/definitions.yaml
@@ -8,10 +8,10 @@ groups:
   checks:
   - id: 1.1
     description: "Ensure a separate partition for containers has been created (Scored)"
-    audit: grep /var/lib/docker /etc/fstab
+    audit: mountpoint -q -- "$(docker info -f '{{ .DockerRootDir }}')" && echo ok
     tests:
       test_items:
-      - flag: "/var/lib/docker"
+      - flag: "ok"
         set: true
     remediation: "For new installations, create a separate partition for /var/lib/docker
     mount point. For systems that were previously installed, use the Logical Volume Manager

--- a/cfg/17.06/definitions.yaml
+++ b/cfg/17.06/definitions.yaml
@@ -8,10 +8,10 @@ groups:
   checks:
   - id: 1.1
     description: "Ensure a separate partition for containers has been created (Scored)"
-    audit: grep /var/lib/docker /etc/fstab
+    audit: mountpoint -q -- "$(docker info -f '{{ .DockerRootDir }}')" && echo ok
     tests:
       test_items:
-      - flag: "/var/lib/docker"
+      - flag: "ok"
         set: true
     remediation: "For new installations, create a separate partition for /var/lib/docker
     mount point. For systems that were previously installed, use the Logical Volume Manager

--- a/cfg/ocp-3.9/definitions.yaml
+++ b/cfg/ocp-3.9/definitions.yaml
@@ -8,10 +8,10 @@ groups:
   checks:
   - id: 1.1
     description: "Ensure a separate partition for containers has been created (Scored)"
-    audit: grep /var/lib/docker /etc/fstab
+    audit: mountpoint -q -- "$(docker info -f '{{ .DockerRootDir }}')" && echo ok
     tests:
       test_items:
-      - flag: "/var/lib/docker"
+      - flag: "ok"
         set: true
     remediation: "For new installations, create a separate partition for /var/lib/docker
     mount point. For systems that were previously installed, use the Logical Volume Manager


### PR DESCRIPTION
In the old check there was just a check if /var/lib/docker is defined just in fstab, but there are more ways to mount it (e.g. with a systemd service).
old check could also match if its commented out with # /var/lib/docker