### PR TITLE
adding multiple templates for github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug report
+about: I would like to report a bug within the project
+labels: bug
+---
+
+### What happened
+
+<!---
+  Please explain in detail steps you took and what happened.
+-->
+
+### Expected behavior
+
+<!---
+  What should happen, ideally?
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: I have a suggestion (and might want to implement myself)
+labels: enhancement
+---
+
+## What would you like to be added
+
+<!---
+  Please describe the idea you have and the problem you are trying to solve.
+-->
+
+## Why is this needed
+
+<!---
+  Please explain why is this feature needed and how it improves the project.
+-->

--- a/.github/ISSUE_TEMPLATE/support_question.md
+++ b/.github/ISSUE_TEMPLATE/support_question.md
@@ -1,0 +1,23 @@
+---
+name: Support Question
+about: I have a question and require assistance
+labels: question
+---
+
+<!--
+  If you have some trouble, feel free to ask.
+  Make sure you're not asking duplicate question by searching on the issues lists.
+-->
+
+## What are you trying to achieve
+
+<!--
+  Explain the problem you are experiencing.
+-->
+
+## Minimal example (if applicable)
+
+<!--
+  If it is possible, create a minimal example of your work that showcases
+  the problem you are having.
+-->


### PR DESCRIPTION
This PR adds GitHub issue templates according to [the latest Github guidelines for multiple issue templates](https://help.github.com/en/articles/about-issue-and-pull-request-templates).

Added three templates:
- bug report template with `bug` label
- feature request template with `enhancement ` label
- support question template with `question` label