### PR TITLE
Fix issues about daemon.json

### DIFF
--- a/cfg/1.13.0/definitions.yaml
+++ b/cfg/1.13.0/definitions.yaml
@@ -208,7 +208,7 @@ groups:
       approach of segmenting networks should be adopted instead.
     scored: true
 
-  - id: 2.2
+  - id: 2.2.a
     description: "Set the logging level (Scored)"
     audit: "ps -ef | grep docker"
     tests:
@@ -222,9 +222,29 @@ groups:
           value: "info"
         set: true
     remediation: |
-      ps -ef | grep docker
+      Ensure that the Docker daemon configuration file has the following configuration included
+      "log-level": "info"
+      Alternatively, run the Docker daemon as below:
+      dockerd --log-level="info"
     scored: true
-
+  
+  - id: 2.2.b
+    description: "Set the logging level (Scored)"
+    audit: "grep log-level /etc/docker/daemon.json"
+    tests:
+      test_items:
+      - flag: '"log-level"'
+        compare:
+          op: eq
+          value: "info"
+        set: true
+    remediation: |
+      Ensure that the Docker daemon configuration file has the following configuration included
+      "log-level": "info"
+      Alternatively, run the Docker daemon as below:
+      dockerd --log-level="info"
+    scored: true
+    
   - id: 2.3
     description: "Allow Docker to make changes to iptables (Scored)"
     audit: "ps -ef | grep dockerd"
@@ -270,10 +290,11 @@ groups:
       dockerd --storage-driver aufs
     scored: true
 
-  - id: 2.6
+  - id: 2.6.a
     description: "Configure TLS authentication for Docker daemon (Scored)"
-    audit: ps -ef | grep dockerd
+    audit: "ps -ef | grep dockerd"
     tests:
+      bin_op: and
       test_items:
       - flag: "--tlsverify"
         set: true
@@ -282,6 +303,36 @@ groups:
       - flag: "--tlscert"
         set: true
       - flag: "--tlskey"
+        set: true
+    remediation: |
+      Follow the steps mentioned in the Docker documentation or other references.
+    scored: true
+    
+  - id: 2.6.b
+    description: "Configure TLS authentication for Docker daemon (Scored)"
+    audit: 'grep tls /etc/docker/daemon.json | tr -d ","'
+    tests:
+      bin_op: and
+      test_items:
+      - flag: '"tlsverify"'
+        compare:
+          op: eq
+          value: true
+        set: true
+      - flag: '"tlscacert"'
+        compare:
+          op: noteq
+          value: '""'
+        set: true
+      - flag: '"tlscert"'
+        compare:
+          op: noteq
+          value: '""'
+        set: true
+      - flag: '"tlskey"'
+        compare:
+          op: noteq
+          value: '""'
         set: true
     remediation: |
       Follow the steps mentioned in the Docker documentation or other references.
@@ -324,7 +375,7 @@ groups:
       dockerd --userns-remap=default
     scored: true
 
-  - id: 2.9
+  - id: 2.9.a
     description: "Confirm default cgroup usage (Scored)"
     audit: ps -ef | grep dockerd
     tests:
@@ -343,8 +394,31 @@ groups:
       For Example,
       dockerd --cgroup-parent=/foobar
     scored: true
-
-  - id: 2.10
+  
+  - id: 2.9.b
+    description: "Confirm default cgroup usage (Scored)"
+    audit: "grep cgroup-parent /etc/docker/daemon.json"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: ""
+        compare:
+          op: eq
+          value: ""
+        set: false
+      - flag: '"cgroup-parent"'
+        compare:
+          op: nothave
+          value: "/docker"
+        set: true
+    remediation: |
+      The default setting is good enough and can be left as-is. If you want to specifically set a non-
+      default cgroup, pass --cgroup-parent parameter to the docker daemon when starting it.
+      For Example,
+      dockerd --cgroup-parent=/foobar
+    scored: true
+    
+  - id: 2.10.a
     description: "Do not change base device size until needed (Scored)"
     audit: ps -ef | grep dockerd
     tests:
@@ -354,8 +428,22 @@ groups:
     remediation: |
       Do not set --storage-opt dm.basesize until needed.
     scored: true
-
-  - id: 2.11
+  
+  - id: 2.10.b
+    description: "Do not change base device size until needed (Scored)"
+    audit: "grep storage-opt /etc/docker/daemon.json"
+    tests:
+      test_items:
+      - flag: '"storage-opt"'
+        compare:
+          op: eq
+          value: ""
+        set: true
+    remediation: |
+      Do not set --storage-opt dm.basesize until needed.
+    scored: true
+    
+  - id: 2.11.a
     description: "Use authorization plugin (Scored)"
     audit: ps -ef | grep dockerd
     tests:
@@ -369,6 +457,23 @@ groups:
       dockerd --authorization-plugin=<PLUGIN_ID>
     scored: true
 
+  - id: 2.11.b
+    description: "Use authorization plugin (Scored)"
+    audit: 'grep authorization-plugin /etc/docker/daemon.json | tr -d ","'
+    tests:
+      test_items:
+      - flag: '"authorization-plugins"'
+        compare:
+          op: noteq
+          value: "[]"
+        set: true
+    remediation: |
+      Step 1: Install/Create an authorization plugin.
+      Step 2: Configure the authorization policy as desired.
+      Step 3: Start the docker daemon as below:
+      dockerd --authorization-plugin=<PLUGIN_ID>
+    scored: true
+    
   - id: 2.12
     description: "Configure centralized and remote logging (Scored)"
     audit: ps -ef | grep dockerd
@@ -396,7 +501,7 @@ groups:
       dockerd --disable-legacy-registry
     scored: true
 
-  - id: 2.14
+  - id: 2.14.a
     description: "Enable live restore (Scored)"
     audit: ps -ef | grep dockerd
     tests:
@@ -409,6 +514,22 @@ groups:
       dockerd --live-restore
     scored: true
 
+  - id: 2.14.b
+    description: "Enable live restore (Scored)"
+    audit: 'grep live-restore /etc/docker/daemon.json | tr -d ","'
+    tests:
+      test_items:
+      - flag: '"live-restore"'
+        compare:
+          op: eq
+          value: "true"
+        set: true
+    remediation: |
+      Run the docker in daemon mode and pass --live-restore as an argument.
+      For Example,
+      dockerd --live-restore
+    scored: true
+    
   - id: 2.15
     description: "Do not enable swarm mode, if not needed (Scored)"
     audit: docker info --format '{{ .Swarm }}'
@@ -438,9 +559,9 @@ groups:
       for the --listen-addr parameter.
     scored: true
 
-  - id: 2.18
+  - id: 2.18.a
     description: "Disable Userland Proxy (Scored)"
-    audit: ps -ef | grep dockerd
+    audit: "ps -ef | grep dockerd"
     tests:
       test_items:
       - flag: "--userland-proxy"
@@ -452,7 +573,22 @@ groups:
       Run the Docker daemon as below:
       dockerd --userland-proxy=false
     scored: true
-
+  
+  - id: 2.18.b
+    description: "Disable Userland Proxy (Scored)"
+    audit: 'grep userland-proxy /etc/docker/daemon.json | tr -d ","'
+    tests:
+      test_items:
+      - flag: '"userland-proxy"'
+        compare:
+          op: eq
+          value: "false"
+        set: true
+    remediation: |
+      Run the Docker daemon as below:
+      dockerd --userland-proxy=false
+    scored: true
+    
   - id: 2.19
     description: "Encrypt data exchanged between containers on different nodes
     on the overlay network (Scored)"
@@ -1229,7 +1365,7 @@ groups:
           op: noteq
           value: ""
         set: true
-       - flag: "RestartPolicyName"
+      - flag: "RestartPolicyName"
         compare:
           op: eq
           value: "no"
@@ -1367,7 +1503,7 @@ groups:
       Do not use --cgroup-parent option in docker run command unless needed.
     scored: true
 
-  - id: 5.25
+  - id: 5.25.a
     description: "Ensure the container is restricted from acquiring additional
     privileges (Scored)"
     audit: docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}:SecurityOpt={{ .HostConfig.SecurityOpt }}'
@@ -1380,7 +1516,23 @@ groups:
       For example, you should start your container as below:
       docker run --rm -it --security-opt=no-new-privileges ubuntu bash
     scored: true
-
+  
+  - id: 5.25.b
+    description: "Ensure the container is restricted from acquiring additional
+    privileges (Scored)"
+    audit: 'grep no-new-privileges /etc/docker/daemon.json | tr -d ","'
+    tests:
+      test_items:
+      - flag: '"no-new-privileges"'
+        compare:
+          op: eq
+          value: "true"
+        set: true
+    remediation: |
+      For example, you should start your container as below:
+      docker run --rm -it --security-opt=no-new-privileges ubuntu bash
+    scored: true
+    
   - id: 5.26
     description: "Ensure container health is checked at runtime (Scored)"
     type: manual

--- a/cfg/17.06/definitions.yaml
+++ b/cfg/17.06/definitions.yaml
@@ -209,7 +209,7 @@ groups:
       approach of segmenting networks should be adopted instead.
     scored: true
 
-  - id: 2.2
+  - id: 2.2.a
     description: "Ensure the logging level is set to 'info' (Scored)"
     audit: "ps -ef | grep docker"
     tests:
@@ -223,9 +223,29 @@ groups:
           value: "info"
         set: true
     remediation: |
-      ps -ef | grep docker
+      Ensure that the Docker daemon configuration file has the following configuration included
+      "log-level": "info"
+      Alternatively, run the Docker daemon as below:
+      dockerd --log-level="info"
     scored: true
 
+  - id: 2.2.b
+    description: "Ensure the logging level is set to 'info' (Scored)"
+    audit: "grep log-level /etc/docker/daemon.json"
+    tests:
+      test_items:
+      - flag: "\"log-level\""
+        compare:
+          op: eq
+          value: "info"
+        set: true
+    remediation: |
+      Ensure that the Docker daemon configuration file has the following configuration included
+      "log-level": "info"
+      Alternatively, run the Docker daemon as below:
+      dockerd --log-level="info"
+    scored: true
+    
   - id: 2.3
     description: "Ensure Docker is allowed to make changes to iptables (Scored)"
     audit: "ps -ef | grep dockerd"
@@ -271,10 +291,11 @@ groups:
       dockerd --storage-driver aufs
     scored: true
 
-  - id: 2.6
+  - id: 2.6.a
     description: "Ensure TLS authentication for Docker daemon is configured (Scored)"
-    audit: ps -ef | grep dockerd
+    audit: "ps -ef | grep dockerd"
     tests:
+      bin_op: and
       test_items:
       - flag: "--tlsverify"
         set: true
@@ -283,6 +304,36 @@ groups:
       - flag: "--tlscert"
         set: true
       - flag: "--tlskey"
+        set: true
+    remediation: |
+      Follow the steps mentioned in the Docker documentation or other references.
+    scored: true
+    
+  - id: 2.6.b
+    description: "Ensure TLS authentication for Docker daemon is configured (Scored)"
+    audit: 'grep tls /etc/docker/daemon.json | tr -d ","'
+    tests:
+      bin_op: and
+      test_items:
+      - flag: '"tlsverify"'
+        compare:
+          op: eq
+          value: true
+        set: true
+      - flag: '"tlscacert"'
+        compare:
+          op: noteq
+          value: '""'
+        set: true
+      - flag: '"tlscert"'
+        compare:
+          op: noteq
+          value: '""'
+        set: true
+      - flag: '"tlskey"'
+        compare:
+          op: noteq
+          value: '""'
         set: true
     remediation: |
       Follow the steps mentioned in the Docker documentation or other references.
@@ -325,7 +376,7 @@ groups:
       dockerd --userns-remap=default
     scored: true
 
-  - id: 2.9
+  - id: 2.9.a
     description: "Ensure the default cgroup usage has been confirmed (Scored)"
     audit: ps -ef | grep dockerd
     tests:
@@ -344,8 +395,31 @@ groups:
       For Example,
       dockerd --cgroup-parent=/foobar
     scored: true
+  
+  - id: 2.9.b
+    description: "Ensure the default cgroup usage has been confirmed (Scored)"
+    audit: "grep cgroup-parent /etc/docker/daemon.json"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: ""
+        compare:
+          op: eq
+          value: ""
+        set: false
+      - flag: '"cgroup-parent"'
+        compare:
+          op: nothave
+          value: "/docker"
+        set: true
+    remediation: |
+      The default setting is good enough and can be left as-is. If you want to specifically set a non-
+      default cgroup, pass --cgroup-parent parameter to the docker daemon when starting it.
+      For Example,
+      dockerd --cgroup-parent=/foobar
+    scored: true
 
-  - id: 2.10
+  - id: 2.10.a
     description: "Ensure base device size is not changed until needed (Scored)"
     audit: ps -ef | grep dockerd
     tests:
@@ -355,14 +429,44 @@ groups:
     remediation: |
       Do not set --storage-opt dm.basesize until needed.
     scored: true
+  
+  - id: 2.10.b
+    description: "Ensure base device size is not changed until needed (Scored)"
+    audit: "grep storage-opt /etc/docker/daemon.json"
+    tests:
+      test_items:
+      - flag: '"storage-opt"'
+        compare:
+          op: eq
+          value: ""
+        set: true
+    remediation: |
+      Do not set --storage-opt dm.basesize until needed.
+    scored: true
 
-  - id: 2.11
-    description: "Ensure that authorization for Docker client commands is enabled
-    (Scored)"
+  - id: 2.11.a
+    description: "Ensure that authorization for Docker client commands is enabled (Scored)"
     audit: ps -ef | grep dockerd
     tests:
       test_items:
       - flag: "--authorization-plugin"
+        set: true
+    remediation: |
+      Step 1: Install/Create an authorization plugin.
+      Step 2: Configure the authorization policy as desired.
+      Step 3: Start the docker daemon as below:
+      dockerd --authorization-plugin=<PLUGIN_ID>
+    scored: true
+
+  - id: 2.11.b
+    description: "Ensure that authorization for Docker client commands is enabled (Scored)"
+    audit: 'grep authorization-plugin /etc/docker/daemon.json | tr -d ","'
+    tests:
+      test_items:
+      - flag: '"authorization-plugins"'
+        compare:
+          op: noteq
+          value: "[]"
         set: true
     remediation: |
       Step 1: Install/Create an authorization plugin.
@@ -398,7 +502,7 @@ groups:
       dockerd --disable-legacy-registry
     scored: true
 
-  - id: 2.14
+  - id: 2.14.a
     description: "Ensure live restore is Enabled (Scored)"
     audit: ps -ef | grep dockerd
     tests:
@@ -411,12 +515,43 @@ groups:
       dockerd --live-restore
     scored: true
 
-  - id: 2.15
+  - id: 2.14.b
+    description: "Ensure live restore is Enabled (Scored)"
+    audit: 'grep live-restore /etc/docker/daemon.json | tr -d ","'
+    tests:
+      test_items:
+      - flag: '"live-restore"'
+        compare:
+          op: eq
+          value: "true"
+        set: true
+    remediation: |
+      Run the docker in daemon mode and pass --live-restore as an argument.
+      For Example,
+      dockerd --live-restore
+    scored: true
+
+  - id: 2.15.a
     description: "Ensure Userland Proxy is Disabled (Scored)"
-    audit: ps -ef | grep dockerd
+    audit: "ps -ef | grep dockerd"
     tests:
       test_items:
       - flag: "--userland-proxy"
+        compare:
+          op: eq
+          value: "false"
+        set: true
+    remediation: |
+      Run the Docker daemon as below:
+      dockerd --userland-proxy=false
+    scored: true
+  
+  - id: 2.15.b
+    description: "Disable Userland Proxy (Scored)"
+    audit: 'grep userland-proxy /etc/docker/daemon.json | tr -d ","'
+    tests:
+      test_items:
+      - flag: '"userland-proxy"'
         compare:
           op: eq
           value: "false"
@@ -459,25 +594,36 @@ groups:
       Do not pass --experimental as a runtime parameter to the docker daemon.
     scored: true
 
-  - id: 2.18
-    description: "Ensure containers are restricted from acquiring new privileges
-    (Scored)"
+  - id: 2.18.a
+    description: "Ensure containers are restricted from acquiring new privileges (Scored)"
     audit: ps -ef | grep dockerd
     tests:
-      bin_op: or
       test_items:
       - flag: "--no-new-privileges"
         compare:
           op: eq
           value: "true"
         set: true
-      - flag: "--no-new-privileges"
-        set: true
     remediation: |
       Run the Docker daemon as below:
       dockerd --no-new-privileges
     scored: true
-
+  
+  - id: 2.18.b
+    description: "Ensure containers are restricted from acquiring new privileges (Scored)"
+    audit: 'grep no-new-privileges /etc/docker/daemon.json | tr -d ","'
+    tests:
+      test_items:
+      - flag: '"no-new-privileges"'
+        compare:
+          op: eq
+          value: "true"
+        set: true
+    remediation: |
+      For example, you should start your container as below:
+      docker run --rm -it --security-opt=no-new-privileges ubuntu bash
+    scored: true
+    
 - id: 3
   description: "Docker daemon configuration files"
   checks:

--- a/cfg/18.09/definitions.yaml
+++ b/cfg/18.09/definitions.yaml
@@ -1377,7 +1377,7 @@ groups:
          give you the CPU share value based on the system. Even if there are no CPU shares
          configured using the -c or --cpu-shares argument in the docker run command,
          this file will have a value of 1024.
-      If you set one containerâ€™s CPU shares to 512 it will receive half of the CPU time compared to
+      If you set one container's CPU shares to 512 it will receive half of the CPU time compared to
       the other containers. So if you take 1024 as 100% you can then derive the number that you
       should set for respective CPU shares. For example, use 512 if you want to set it to 50% and
       256 if you want to set it 25%.

--- a/cfg/18.09/definitions.yaml
+++ b/cfg/18.09/definitions.yaml
@@ -238,7 +238,7 @@ groups:
       dockerd --icc=false
     scored: true
 
-  - id: 2.2
+  - id: 2.2.a
     description: "Ensure the logging level is set to 'info' (Scored)"
     audit: "ps -ef | grep dockerd"
     tests:
@@ -252,9 +252,26 @@ groups:
           value: "info"
         set: true
     remediation: |
-      Ensure that the Docker daemon configuration file has the following configuration included 
+      Ensure that the Docker daemon configuration file has the following configuration included
       "log-level": "info"
-      Alternatively, run the Docker daemon as below: 
+      Alternatively, run the Docker daemon as below:
+      dockerd --log-level="info"
+    scored: true
+
+  - id: 2.2.b
+    description: "Ensure the logging level is set to 'info' (Scored)"
+    audit: "grep log-level /etc/docker/daemon.json"
+    tests:
+      test_items:
+      - flag: "\"log-level\""
+        compare:
+          op: eq
+          value: "info"
+        set: true
+    remediation: |
+      Ensure that the Docker daemon configuration file has the following configuration included
+      "log-level": "info"
+      Alternatively, run the Docker daemon as below:
       dockerd --log-level="info"
     scored: true
 
@@ -298,10 +315,11 @@ groups:
       dockerd --storage-driver aufs
     scored: true
 
-  - id: 2.6
+  - id: 2.6.a
     description: "Ensure TLS authentication for Docker daemon is configured (Scored)"
     audit: "ps -ef | grep dockerd"
     tests:
+      bin_op: and
       test_items:
       - flag: "--tlsverify"
         set: true
@@ -310,6 +328,36 @@ groups:
       - flag: "--tlscert"
         set: true
       - flag: "--tlskey"
+        set: true
+    remediation: |
+      Follow the steps mentioned in the Docker documentation or other references.
+    scored: true
+    
+  - id: 2.6.b
+    description: "Ensure TLS authentication for Docker daemon is configured (Scored)"
+    audit: 'grep tls /etc/docker/daemon.json | tr -d ","'
+    tests:
+      bin_op: and
+      test_items:
+      - flag: '"tlsverify"'
+        compare:
+          op: eq
+          value: true
+        set: true
+      - flag: '"tlscacert"'
+        compare:
+          op: noteq
+          value: '""'
+        set: true
+      - flag: '"tlscert"'
+        compare:
+          op: noteq
+          value: '""'
+        set: true
+      - flag: '"tlskey"'
+        compare:
+          op: noteq
+          value: '""'
         set: true
     remediation: |
       Follow the steps mentioned in the Docker documentation or other references.
@@ -352,7 +400,7 @@ groups:
       dockerd --userns-remap=default
     scored: true
 
-  - id: 2.9
+  - id: 2.9.a
     description: "Ensure the default cgroup usage has been confirmed (Scored)"
     audit: "ps -ef | grep dockerd"
     tests:
@@ -372,8 +420,32 @@ groups:
       For example, 
       dockerd --cgroup-parent=/foobar
     scored: true
+  
+  - id: 2.9.b
+    description: "Ensure the default cgroup usage has been confirmed (Scored)"
+    audit: "grep cgroup-parent /etc/docker/daemon.json"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: ""
+        compare:
+          op: eq
+          value: ""
+        set: false
+      - flag: '"cgroup-parent"'
+        compare:
+          op: nothave
+          value: "/docker"
+        set: true
+    remediation: |
+      The default setting is in line with good security practice and can be left in situ. If you wish 
+      to specifically set a non-default cgroup, pass the --cgroup-parent parameter to the Docker 
+      daemon when starting it. 
+      For example, 
+      dockerd --cgroup-parent=/foobar
+    scored: true
 
-  - id: 2.10
+  - id: 2.10.a
     description: "Ensure base device size is not changed until needed (Scored)"
     audit: "ps -ef | grep dockerd"
     tests:
@@ -383,14 +455,44 @@ groups:
     remediation: |
       Do not set --storage-opt dm.basesize until needed.
     scored: true
+  
+  - id: 2.10.b
+    description: "Ensure base device size is not changed until needed (Scored)"
+    audit: "grep storage-opt /etc/docker/daemon.json"
+    tests:
+      test_items:
+      - flag: '"storage-opt"'
+        compare:
+          op: eq
+          value: ""
+        set: true
+    remediation: |
+      Do not set --storage-opt dm.basesize until needed.
+    scored: true
 
-  - id: 2.11
-    description: "Ensure that authorization for Docker client commands is enabled
-    (Scored)"
+  - id: 2.11.a
+    description: "Ensure that authorization for Docker client commands is enabled (Scored)"
     audit: "ps -ef | grep dockerd"
     tests:
       test_items:
       - flag: "--authorization-plugin"
+        set: true
+    remediation: |
+      Step 1: Install/Create an authorization plugin.
+      Step 2: Configure the authorization policy as desired.
+      Step 3: Start the docker daemon as below:
+      dockerd --authorization-plugin=<PLUGIN_ID>
+    scored: true
+
+  - id: 2.11.b
+    description: "Ensure that authorization for Docker client commands is enabled (Scored)"
+    audit: 'grep authorization-plugin /etc/docker/daemon.json | tr -d ","'
+    tests:
+      test_items:
+      - flag: '"authorization-plugins"'
+        compare:
+          op: noteq
+          value: "[]"
         set: true
     remediation: |
       Step 1: Install/Create an authorization plugin.
@@ -413,7 +515,7 @@ groups:
       dockerd --log-driver=syslog --log-opt syslog-address=tcp://192.xxx.xxx.xxx
     scored: true
 
-  - id: 2.13
+  - id: 2.13.a
     description: "Ensure live restore is Enabled (Scored)"
     audit: "ps -ef | grep dockerd"
     tests:
@@ -426,12 +528,43 @@ groups:
       dockerd --live-restore
     scored: true
 
-  - id: 2.14
+  - id: 2.13.b
+    description: "Ensure live restore is Enabled (Scored)"
+    audit: 'grep live-restore /etc/docker/daemon.json | tr -d ","'
+    tests:
+      test_items:
+      - flag: '"live-restore"'
+        compare:
+          op: eq
+          value: "true"
+        set: true
+    remediation: |
+      Run the docker in daemon mode and pass --live-restore as an argument.
+      For Example,
+      dockerd --live-restore
+    scored: true
+
+  - id: 2.14.a
     description: "Ensure Userland Proxy is Disabled (Scored)"
     audit: "ps -ef | grep dockerd"
     tests:
       test_items:
       - flag: "--userland-proxy"
+        compare:
+          op: eq
+          value: "false"
+        set: true
+    remediation: |
+      You should run the Docker daemon as below:
+      dockerd --userland-proxy=false
+    scored: true
+  
+  - id: 2.14.b
+    description: "Disable Userland Proxy (Scored)"
+    audit: 'grep userland-proxy /etc/docker/daemon.json | tr -d ","'
+    tests:
+      test_items:
+      - flag: '"userland-proxy"'
         compare:
           op: eq
           value: "false"
@@ -475,25 +608,36 @@ groups:
       production systems.
     scored: true
 
-  - id: 2.17
-    description: "Ensure containers are restricted from acquiring new privileges
-    (Scored)"
+  - id: 2.17.a
+    description: "Ensure containers are restricted from acquiring new privileges (Scored)"
     audit: "ps -ef | grep dockerd"
     tests:
-      bin_op: or
       test_items:
       - flag: "--no-new-privileges"
         compare:
           op: eq
           value: "true"
         set: true
-      - flag: "--no-new-privileges"
-        set: true
     remediation: |
       You should run the Docker daemon as below:
       dockerd --no-new-privileges
     scored: true
-
+    
+  - id: 2.17.b
+    description: "Ensure containers are restricted from acquiring new privileges (Scored)"
+    audit: 'grep no-new-privileges /etc/docker/daemon.json | tr -d ","'
+    tests:
+      test_items:
+      - flag: '"no-new-privileges"'
+        compare:
+          op: eq
+          value: "true"
+        set: true
+    remediation: |
+      For example, you should start your container as below:
+      docker run --rm -it --security-opt=no-new-privileges ubuntu bash
+    scored: true
+    
 - id: 3
   description: "Docker daemon configuration files"
   checks:
@@ -1233,7 +1377,7 @@ groups:
          give you the CPU share value based on the system. Even if there are no CPU shares
          configured using the -c or --cpu-shares argument in the docker run command,
          this file will have a value of 1024.
-      If you set one container’s CPU shares to 512 it will receive half of the CPU time compared to
+      If you set one containerâ€™s CPU shares to 512 it will receive half of the CPU time compared to
       the other containers. So if you take 1024 as 100% you can then derive the number that you
       should set for respective CPU shares. For example, use 512 if you want to set it to 50% and
       256 if you want to set it 25%.
@@ -1311,7 +1455,7 @@ groups:
           op: noteq
           value: ""
         set: true
-       - flag: "RestartPolicyName"
+      - flag: "RestartPolicyName"
         compare:
           op: eq
           value: "no"

--- a/cfg/ocp-3.9/definitions.yaml
+++ b/cfg/ocp-3.9/definitions.yaml
@@ -211,7 +211,7 @@ groups:
       approach of segmenting networks should be adopted instead.
     scored: true
 
-  - id: 2.2
+  - id: 2.2.a
     description: "Set the logging level (Scored)"
     audit: "ps -ef | grep docker"
     tests:
@@ -225,9 +225,29 @@ groups:
           value: "info"
         set: true
     remediation: |
-      ps -ef | grep docker
+      Ensure that the Docker daemon configuration file has the following configuration included
+      "log-level": "info"
+      Alternatively, run the Docker daemon as below:
+      dockerd --log-level="info"
     scored: true
-
+  
+  - id: 2.2.b
+    description: "Set the logging level (Scored)"
+    audit: "grep log-level /etc/docker/daemon.json"
+    tests:
+      test_items:
+      - flag: '"log-level"'
+        compare:
+          op: eq
+          value: "info"
+        set: true
+    remediation: |
+      Ensure that the Docker daemon configuration file has the following configuration included
+      "log-level": "info"
+      Alternatively, run the Docker daemon as below:
+      dockerd --log-level="info"
+    scored: true
+    
   - id: 2.3
     description: "Allow Docker to make changes to iptables (Scored)"
     audit: "ps -ef | grep dockerd"
@@ -273,10 +293,11 @@ groups:
       dockerd --storage-driver aufs
     scored: true
 
-  - id: 2.6
+  - id: 2.6.a
     description: "Configure TLS authentication for Docker daemon (Scored)"
-    audit: ps -ef | grep dockerd
+    audit: "ps -ef | grep dockerd"
     tests:
+      bin_op: and
       test_items:
       - flag: "--tlsverify"
         set: true
@@ -285,6 +306,36 @@ groups:
       - flag: "--tlscert"
         set: true
       - flag: "--tlskey"
+        set: true
+    remediation: |
+      Follow the steps mentioned in the Docker documentation or other references.
+    scored: true
+    
+  - id: 2.6.b
+    description: "Configure TLS authentication for Docker daemon (Scored)"
+    audit: 'grep tls /etc/docker/daemon.json | tr -d ","'
+    tests:
+      bin_op: and
+      test_items:
+      - flag: '"tlsverify"'
+        compare:
+          op: eq
+          value: true
+        set: true
+      - flag: '"tlscacert"'
+        compare:
+          op: noteq
+          value: '""'
+        set: true
+      - flag: '"tlscert"'
+        compare:
+          op: noteq
+          value: '""'
+        set: true
+      - flag: '"tlskey"'
+        compare:
+          op: noteq
+          value: '""'
         set: true
     remediation: |
       Follow the steps mentioned in the Docker documentation or other references.
@@ -327,7 +378,7 @@ groups:
       dockerd --userns-remap=default
     scored: true
 
-  - id: 2.9
+  - id: 2.9.a
     description: "Confirm default cgroup usage (Scored)"
     audit: ps -ef | grep dockerd
     tests:
@@ -346,8 +397,31 @@ groups:
       For Example,
       dockerd --cgroup-parent=/foobar
     scored: true
+  
+  - id: 2.9.b
+    description: "Confirm default cgroup usage (Scored)"
+    audit: "grep cgroup-parent /etc/docker/daemon.json"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: ""
+        compare:
+          op: eq
+          value: ""
+        set: false
+      - flag: '"cgroup-parent"'
+        compare:
+          op: nothave
+          value: "/docker"
+        set: true
+    remediation: |
+      The default setting is good enough and can be left as-is. If you want to specifically set a non-
+      default cgroup, pass --cgroup-parent parameter to the docker daemon when starting it.
+      For Example,
+      dockerd --cgroup-parent=/foobar
+    scored: true
 
-  - id: 2.10
+  - id: 2.10.a
     description: "Do not change base device size until needed (Scored)"
     audit: ps -ef | grep dockerd
     tests:
@@ -357,13 +431,44 @@ groups:
     remediation: |
       Do not set --storage-opt dm.basesize until needed.
     scored: true
-
-  - id: 2.11
+  
+  - id: 2.10.b
+    description: "Do not change base device size until needed (Scored)"
+    audit: "grep storage-opt /etc/docker/daemon.json"
+    tests:
+      test_items:
+      - flag: '"storage-opt"'
+        compare:
+          op: eq
+          value: ""
+        set: true
+    remediation: |
+      Do not set --storage-opt dm.basesize until needed.
+    scored: true
+    
+  - id: 2.11.a
     description: "Use authorization plugin (Scored)"
     audit: ps -ef | grep dockerd
     tests:
       test_items:
       - flag: "--authorization-plugin"
+        set: true
+    remediation: |
+      Step 1: Install/Create an authorization plugin.
+      Step 2: Configure the authorization policy as desired.
+      Step 3: Start the docker daemon as below:
+      dockerd --authorization-plugin=<PLUGIN_ID>
+    scored: true
+
+  - id: 2.11.b
+    description: "Use authorization plugin (Scored)"
+    audit: 'grep authorization-plugin /etc/docker/daemon.json | tr -d ","'
+    tests:
+      test_items:
+      - flag: '"authorization-plugins"'
+        compare:
+          op: noteq
+          value: "[]"
         set: true
     remediation: |
       Step 1: Install/Create an authorization plugin.
@@ -399,12 +504,28 @@ groups:
       dockerd --disable-legacy-registry
     scored: true
 
-  - id: 2.14
+  - id: 2.14.a
     description: "Enable live restore (Scored)"
     audit: ps -ef | grep dockerd
     tests:
       test_items:
       - flag: "--live-restore"
+        set: true
+    remediation: |
+      Run the docker in daemon mode and pass --live-restore as an argument.
+      For Example,
+      dockerd --live-restore
+    scored: true
+
+  - id: 2.14.b
+    description: "Enable live restore (Scored)"
+    audit: 'grep live-restore /etc/docker/daemon.json | tr -d ","'
+    tests:
+      test_items:
+      - flag: '"live-restore"'
+        compare:
+          op: eq
+          value: "true"
         set: true
     remediation: |
       Run the docker in daemon mode and pass --live-restore as an argument.
@@ -441,12 +562,27 @@ groups:
 #      for the --listen-addr parameter.
 #    scored: true
 
-  - id: 2.18
+  - id: 2.18.a
     description: "Disable Userland Proxy (Scored)"
-    audit: ps -ef | grep dockerd
+    audit: "ps -ef | grep dockerd"
     tests:
       test_items:
       - flag: "--userland-proxy"
+        compare:
+          op: eq
+          value: "false"
+        set: true
+    remediation: |
+      Run the Docker daemon as below:
+      dockerd --userland-proxy=false
+    scored: true
+  
+  - id: 2.18.b
+    description: "Disable Userland Proxy (Scored)"
+    audit: 'grep userland-proxy /etc/docker/daemon.json | tr -d ","'
+    tests:
+      test_items:
+      - flag: '"userland-proxy"'
         compare:
           op: eq
           value: "false"
@@ -1235,7 +1371,7 @@ groups:
           op: noteq
           value: ""
         set: true
-       - flag: "RestartPolicyName"
+      - flag: "RestartPolicyName"
         compare:
           op: eq
           value: "no"
@@ -1373,7 +1509,7 @@ groups:
       Do not use --cgroup-parent option in docker run command unless needed.
     scored: true
 
-  - id: 5.25
+  - id: 5.25.a
     description: "Ensure the container is restricted from acquiring additional
     privileges (Scored)"
     audit: docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}:SecurityOpt={{ .HostConfig.SecurityOpt }}'
@@ -1381,6 +1517,22 @@ groups:
     tests:
       test_items:
       - flag: "no-new-privileges"
+        set: true
+    remediation: |
+      For example, you should start your container as below:
+      docker run --rm -it --security-opt=no-new-privileges ubuntu bash
+    scored: true
+  
+  - id: 5.25.b
+    description: "Ensure the container is restricted from acquiring additional
+    privileges (Scored)"
+    audit: 'grep no-new-privileges /etc/docker/daemon.json | tr -d ","'
+    tests:
+      test_items:
+      - flag: '"no-new-privileges"'
+        compare:
+          op: eq
+          value: "true"
         set: true
     remediation: |
       For example, you should start your container as below:


### PR DESCRIPTION
Update cfg files in order to check daemon.json file as well.
Changes are according to CIS, where in notes has the following comment 

> Ensure that either the XXX parameter is not present or if present, then it is set to
info.
The contents of /etc/docker/daemon.json should also be reviewed for this setting

(XXX is the different parameter between tests)
Addressing issues #64 #65 #66  #67  and some more tests 