### PR TITLE
Add bitmask use

### DIFF
--- a/cfg/1.13.0/definitions.yaml
+++ b/cfg/1.13.0/definitions.yaml
@@ -526,12 +526,12 @@ groups:
   - id: 3.2
     description: "Ensure that docker.service file permissions are set to 644 or more
     restrictive (Scored)"
-    audit: systemctl show -p FragmentPath docker.service | cut -d= -f2 | xargs stat -c %a
+    audit: systemctl show -p FragmentPath docker.service | cut -d= -f2 | xargs stat -c "permissions=%a"
     tests:
       test_items:
-      - flag: "644"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "644"
         set: true
     remediation: |
@@ -566,12 +566,12 @@ groups:
   - id: 3.4
     description: "Ensure that docker.socket file permissions are set to 644 or more
     restrictive (Scored)"
-    audit: systemctl show -p FragmentPath docker.socket | cut -d= -f2 | xargs stat -c %a
+    audit: systemctl show -p FragmentPath docker.socket | cut -d= -f2 | xargs stat -c "permissions=%a"
     tests:
       test_items:
-      - flag: "644"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "644"
         set: true
     remediation: |
@@ -602,24 +602,13 @@ groups:
   - id: 3.6
     description: "Ensure that /etc/docker directory permissions are set to 755 or more
     restrictive (Scored)"
-    audit: stat -c %a /etc/docker
+    audit: stat -c "permissions=%a" /etc/docker
     tests:
-      bin_op: or
       test_items:
-      - flag: "755"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "755"
-        set: true
-      - flag: "750"
-        compare:
-          op: eq
-          value: "750"
-        set: true
-      - flag: "700"
-        compare:
-          op: eq
-          value: "700"
         set: true
     remediation: |
       chmod 755 /etc/docker
@@ -642,12 +631,12 @@ groups:
   - id: 3.8
     description: "Ensure that registry certificate file permissions are set to 444 or
     more restrictive (Scored)"
-    audit: /bin/sh -c "if [ -d /etc/docker/certs.d ]; then stat -c %a /etc/docker/certs.d/*; fi"
+    audit: /bin/sh -c "if [ -d /etc/docker/certs.d ]; then stat -c "permissions=%a" /etc/docker/certs.d/*; fi"
     tests:
       test_items:
-      - flag: "444"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "444"
         set: true
     remediation: |
@@ -731,20 +720,13 @@ groups:
   - id: 3.16
     description: "Ensure that Docker socket file permissions are set to 660 or more
     restrictive (Scored)"
-    audit: /bin/sh -c "if [ -f /var/run/docker.sock ]; then stat -c %a /var/run/docker.sock; fi"
+    audit: /bin/sh -c "if [ -f /var/run/docker.sock ]; then stat -c "permissions=%a" /var/run/docker.sock; fi"
     tests:
-      bin_op: or
       test_items:
-      - flag: "660"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "660"
-        set: true
-      test_items:
-      - flag: "600"
-        compare:
-          op: eq
-          value: "600"
         set: true
     remediation: |
       chmod 660 /var/run/docker.sock
@@ -769,24 +751,14 @@ groups:
   - id: 3.18
     description: "Ensure that daemon.json file permissions are set to 644 or more
     restrictive (Scored)"
-    audit: /bin/sh -c "if [ -f /etc/docker/daemon.json ]; then stat -c %a /etc/docker/daemon.json; fi"
+    audit: /bin/sh -c "if [ -f /etc/docker/daemon.json ]; then stat -c "permissions=%a" /etc/docker/daemon.json; fi"
     tests:
       bin_op: or
       test_items:
-      - flag: "644"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "644"
-        set: true
-      - flag: "640"
-        compare:
-          op: eq
-          value: "640"
-        set: true
-      - flag: "600"
-        compare:
-          op: eq
-          value: "600"
         set: true
     remediation: |
       chown root:root /etc/default/docker
@@ -812,24 +784,13 @@ groups:
   - id: 3.20
     description: "Ensure that /etc/default/docker file permissions are set to 644 or
     more restrictive (Scored)"
-    audit: /bin/sh -c "if [ -f /etc/default/docker ]; then stat -c %a /etc/default/docker; fi"
+    audit: /bin/sh -c "if [ -f /etc/default/docker ]; then stat -c "permissions=%a" /etc/default/docker; fi"
     tests:
-      bin_op: or
       test_items:
-      - flag: "644"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "644"
-        set: true
-      - flag: "640"
-        compare:
-          op: eq
-          value: "640"
-        set: true
-      - flag: "600"
-        compare:
-          op: eq
-          value: "600"
         set: true
     remediation: |
       chmod 644 /etc/default/docker
@@ -1229,7 +1190,7 @@ groups:
           op: noteq
           value: ""
         set: true
-       - flag: "RestartPolicyName"
+      - flag: "RestartPolicyName"
         compare:
           op: eq
           value: "no"

--- a/cfg/17.06/definitions.yaml
+++ b/cfg/17.06/definitions.yaml
@@ -504,12 +504,12 @@ groups:
   - id: 3.2
     description: "Ensure that docker.service file permissions are set to 644 or more
     restrictive (Scored)"
-    audit: systemctl show -p FragmentPath docker.service | cut -d= -f2 | xargs stat -c %a
+    audit: systemctl show -p FragmentPath docker.service | cut -d= -f2 | xargs stat -c "permissions=%a"
     tests:
       test_items:
-      - flag: "644"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "644"
         set: true
     remediation: |
@@ -544,12 +544,12 @@ groups:
   - id: 3.4
     description: "Ensure that docker.socket file permissions are set to 644 or more
     restrictive (Scored)"
-    audit: systemctl show -p FragmentPath docker.socket | cut -d= -f2 | xargs stat -c %a
+    audit: systemctl show -p FragmentPath docker.socket | cut -d= -f2 | xargs stat -c "permissions=%a"
     tests:
       test_items:
-      - flag: "644"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "644"
         set: true
     remediation: |
@@ -580,24 +580,13 @@ groups:
   - id: 3.6
     description: "Ensure that /etc/docker directory permissions are set to 755 or more
     restrictive (Scored)"
-    audit: stat -c %a /etc/docker
+    audit: stat -c "permissions=%a" /etc/docker
     tests:
-      bin_op: or
       test_items:
-      - flag: "755"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "755"
-        set: true
-      - flag: "750"
-        compare:
-          op: eq
-          value: "750"
-        set: true
-      - flag: "700"
-        compare:
-          op: eq
-          value: "700"
         set: true
     remediation: |
       chmod 755 /etc/docker
@@ -620,12 +609,12 @@ groups:
   - id: 3.8
     description: "Ensure that registry certificate file permissions are set to 444 or
     more restrictive (Scored)"
-    audit: stat -c %a /etc/docker/certs.d/*
+    audit: stat -c "permissions=%a" /etc/docker/certs.d/*
     tests:
       test_items:
-      - flag: "444"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "444"
         set: true
     remediation: |
@@ -709,12 +698,12 @@ groups:
   - id: 3.16
     description: "Ensure that Docker socket file permissions are set to 660 or more
     restrictive (Scored)"
-    audit: stat -c %a /var/run/docker.sock
+    audit: stat -c "permissions=%a" /var/run/docker.sock
     tests:
       test_items:
-      - flag: ""
+      - flag: "permissions"
         compare:
-          op: gte
+          op: bitmask
           value: "660"
         set: true
     remediation: |
@@ -740,24 +729,13 @@ groups:
   - id: 3.18
     description: "Ensure that daemon.json file permissions are set to 644 or more
     restrictive (Scored)"
-    audit: /bin/sh -c "if [ -f /etc/docker/daemon.json ]; then stat -c %a /etc/docker/daemon.json; fi"
+    audit: /bin/sh -c "if [ -f /etc/docker/daemon.json ]; then stat -c "permissions=%a" /etc/docker/daemon.json; fi"
     tests:
-      bin_op: or
       test_items:
-      - flag: "644"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "644"
-        set: true
-      - flag: "640"
-        compare:
-          op: eq
-          value: "640"
-        set: true
-      - flag: "600"
-        compare:
-          op: eq
-          value: "600"
         set: true
     remediation: |
       chown root:root /etc/default/docker
@@ -783,24 +761,13 @@ groups:
   - id: 3.20
     description: "Ensure that /etc/default/docker file permissions are set to 644 or
     more restrictive (Scored)"
-    audit: /bin/sh -c "if [ -f /etc/default/docker ]; then stat -c %a /etc/default/docker; fi"
+    audit: /bin/sh -c "if [ -f /etc/default/docker ]; then stat -c "permissions=%a" /etc/default/docker; fi"
     tests:
-      bin_op: or
       test_items:
-      - flag: "644"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "644"
-        set: true
-      - flag: "640"
-        compare:
-          op: eq
-          value: "640"
-        set: true
-      - flag: "600"
-        compare:
-          op: eq
-          value: "600"
         set: true
     remediation: |
       chmod 644 /etc/default/docker

--- a/cfg/18.09/definitions.yaml
+++ b/cfg/18.09/definitions.yaml
@@ -520,12 +520,12 @@ groups:
   - id: 3.2
     description: "Ensure that docker.service file permissions are appropriately set
     (Scored)"
-    audit: systemctl show -p FragmentPath docker.service | cut -d= -f2 | xargs stat -c %a
+    audit: systemctl show -p FragmentPath docker.service | cut -d= -f2 | xargs stat -c "permissions=%a"
     tests:
       test_items:
-      - flag: "644"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "644"
         set: true
     remediation: |
@@ -560,12 +560,12 @@ groups:
   - id: 3.4
     description: "Ensure that docker.socket file permissions are set to 644 or more
     restrictive (Scored)"
-    audit: systemctl show -p FragmentPath docker.socket | cut -d= -f2 | xargs stat -c %a
+    audit: systemctl show -p FragmentPath docker.socket | cut -d= -f2 | xargs stat -c "permissions=%a"
     tests:
       test_items:
-      - flag: "644"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "644"
         set: true
     remediation: |
@@ -598,24 +598,13 @@ groups:
   - id: 3.6
     description: "Ensure that /etc/docker directory permissions are set to 755 or more
     restrictive (Scored)"
-    audit: stat -c %a /etc/docker
+    audit: stat -c "permissions=%a" /etc/docker
     tests:
-      bin_op: or
       test_items:
-      - flag: "755"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "755"
-        set: true
-      - flag: "750"
-        compare:
-          op: eq
-          value: "750"
-        set: true
-      - flag: "700"
-        compare:
-          op: eq
-          value: "700"
         set: true
     remediation: |
       You should run the following command:
@@ -641,12 +630,12 @@ groups:
   - id: 3.8
     description: "Ensure that registry certificate file permissions are set to 444 or
     more restrictive (Scored)"
-    audit: stat -c %a /etc/docker/certs.d/*
+    audit: stat -c "permissions=%a" /etc/docker/certs.d/*
     tests:
       test_items:
-      - flag: "444"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "444"
         set: true
     remediation: |
@@ -737,12 +726,12 @@ groups:
   - id: 3.16
     description: "Ensure that Docker socket file permissions are set to 660 or more
     restrictive (Scored)"
-    audit: stat -c %a /var/run/docker.sock
+    audit: stat -c "permissions=%a" /var/run/docker.sock
     tests:
       test_items:
-      - flag: ""
+      - flag: "permissions"
         compare:
-          op: gte
+          op: bitmask
           value: "660"
         set: true
     remediation: |
@@ -770,24 +759,14 @@ groups:
   - id: 3.18
     description: "Ensure that daemon.json file permissions are set to 644 or more
     restrictive (Scored)"
-    audit: /bin/sh -c "if [ -f /etc/docker/daemon.json ]; then stat -c %a /etc/docker/daemon.json; fi"
+    audit: /bin/sh -c "if [ -f /etc/docker/daemon.json ]; then stat -c "permissions=%a" /etc/docker/daemon.json; fi"
     tests:
       bin_op: or
       test_items:
-      - flag: "644"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "644"
-        set: true
-      - flag: "640"
-        compare:
-          op: eq
-          value: "640"
-        set: true
-      - flag: "600"
-        compare:
-          op: eq
-          value: "600"
         set: true
     remediation: |
       You should execute the command below
@@ -829,24 +808,13 @@ groups:
   - id: 3.21
     description: "Ensure that /etc/sysconfig/docker file permissions are set to 644 or
     more restrictive (Scored)"
-    audit: /bin/sh -c "if [ -f /etc/sysconfig/docker ]; then stat -c %a /etc/sysconfig/docker; fi"
+    audit: /bin/sh -c "if [ -f /etc/sysconfig/docker ]; then stat -c "permissions=%a" /etc/sysconfig/docker; fi"
     tests:
-      bin_op: or
       test_items:
-      - flag: "644"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "644"
-        set: true
-      - flag: "640"
-        compare:
-          op: eq
-          value: "640"
-        set: true
-      - flag: "600"
-        compare:
-          op: eq
-          value: "600"
         set: true
     remediation: |
       You should execute the following command:
@@ -856,24 +824,13 @@ groups:
   - id: 3.22
     description: "Ensure that /etc/default/docker file permissions are set to 644 or
     more restrictive (Scored)"
-    audit: /bin/sh -c "if [ -f /etc/default/docker ]; then stat -c %a /etc/default/docker; fi"
+    audit: /bin/sh -c "if [ -f /etc/default/docker ]; then stat -c "permissions=%a" /etc/default/docker; fi"
     tests:
-      bin_op: or
       test_items:
-      - flag: "644"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "644"
-        set: true
-      - flag: "640"
-        compare:
-          op: eq
-          value: "640"
-        set: true
-      - flag: "600"
-        compare:
-          op: eq
-          value: "600"
         set: true
     remediation: |
       You should execute the following command:
@@ -1233,7 +1190,7 @@ groups:
          give you the CPU share value based on the system. Even if there are no CPU shares
          configured using the -c or --cpu-shares argument in the docker run command,
          this file will have a value of 1024.
-      If you set one container’s CPU shares to 512 it will receive half of the CPU time compared to
+      If you set one containerâ€™s CPU shares to 512 it will receive half of the CPU time compared to
       the other containers. So if you take 1024 as 100% you can then derive the number that you
       should set for respective CPU shares. For example, use 512 if you want to set it to 50% and
       256 if you want to set it 25%.
@@ -1311,7 +1268,7 @@ groups:
           op: noteq
           value: ""
         set: true
-       - flag: "RestartPolicyName"
+      - flag: "RestartPolicyName"
         compare:
           op: eq
           value: "no"

--- a/cfg/18.09/definitions.yaml
+++ b/cfg/18.09/definitions.yaml
@@ -1190,7 +1190,7 @@ groups:
          give you the CPU share value based on the system. Even if there are no CPU shares
          configured using the -c or --cpu-shares argument in the docker run command,
          this file will have a value of 1024.
-      If you set one containerâ€™s CPU shares to 512 it will receive half of the CPU time compared to
+      If you set one container's CPU shares to 512 it will receive half of the CPU time compared to
       the other containers. So if you take 1024 as 100% you can then derive the number that you
       should set for respective CPU shares. For example, use 512 if you want to set it to 50% and
       256 if you want to set it 25%.

--- a/cfg/ocp-3.9/definitions.yaml
+++ b/cfg/ocp-3.9/definitions.yaml
@@ -529,12 +529,12 @@ groups:
   - id: 3.2
     description: "Ensure that docker.service file permissions are set to 644 or more
     restrictive (Scored)"
-    audit: systemctl show -p FragmentPath docker.service | cut -d= -f2 | xargs stat -c %a
+    audit: systemctl show -p FragmentPath docker.service | cut -d= -f2 | xargs stat -c "permissions=%a"
     tests:
       test_items:
-      - flag: "644"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "644"
         set: true
     remediation: |
@@ -569,12 +569,12 @@ groups:
   - id: 3.4
     description: "Ensure that docker.socket file permissions are set to 644 or more
     restrictive (Scored)"
-    audit: systemctl show -p FragmentPath docker.socket | cut -d= -f2 | xargs stat -c %a
+    audit: systemctl show -p FragmentPath docker.socket | cut -d= -f2 | xargs stat -c "permissions=%a"
     tests:
       test_items:
-      - flag: "644"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "644"
         set: true
     remediation: |
@@ -605,24 +605,13 @@ groups:
   - id: 3.6
     description: "Ensure that /etc/docker directory permissions are set to 755 or more
     restrictive (Scored)"
-    audit: stat -c %a /etc/docker
+    audit: stat -c "permissions=%a" /etc/docker
     tests:
-      bin_op: or
       test_items:
-      - flag: "755"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "755"
-        set: true
-      - flag: "750"
-        compare:
-          op: eq
-          value: "750"
-        set: true
-      - flag: "700"
-        compare:
-          op: eq
-          value: "700"
         set: true
     remediation: |
       chmod 755 /etc/docker
@@ -648,12 +637,12 @@ groups:
   - id: 3.8
     description: "Ensure that registry certificate file permissions are set to 444 or
     more restrictive (Scored)"
-    audit: /bin/sh -c "if [ -d /etc/docker/certs.d ]; then stat -c %a /etc/docker/certs.d/*; fi"
+    audit: /bin/sh -c "if [ -d /etc/docker/certs.d ]; then stat -c "permissions=%a" /etc/docker/certs.d/*; fi"
     tests:
       test_items:
-      - flag: "444"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "444"
         set: true
     remediation: |
@@ -737,20 +726,13 @@ groups:
   - id: 3.16
     description: "Ensure that Docker socket file permissions are set to 660 or more
     restrictive (Scored)"
-    audit: /bin/sh -c "if [ -f /var/run/docker.sock ]; then stat -c %a /var/run/docker.sock; fi"
+    audit: /bin/sh -c "if [ -f /var/run/docker.sock ]; then stat -c "permissions=%a" /var/run/docker.sock; fi"
     tests:
-      bin_op: or
       test_items:
-      - flag: "660"
+      - flag: "permissions"
         compare:
-          op: eq
+          op: bitmask
           value: "660"
-        set: true
-      test_items:
-      - flag: "600"
-        compare:
-          op: eq
-          value: "600"
         set: true
     remediation: |
       chmod 660 /var/run/docker.sock
@@ -1235,7 +1217,7 @@ groups:
           op: noteq
           value: ""
         set: true
-       - flag: "RestartPolicyName"
+      - flag: "RestartPolicyName"
         compare:
           op: eq
           value: "no"


### PR DESCRIPTION
Update the cfg files to include the option bitmask comparison which will better check files permission when test is #XXX or more restrict  https://github.com/aquasecurity/docker-bench/issues/73