### PR TITLE
ausearch checks were not workings as expected because of audit logs

### DIFF
--- a/cfg/cis-1.0/config.yaml
+++ b/cfg/cis-1.0/config.yaml
@@ -5,3 +5,5 @@
 
 docker-storage:
   value: /var/lib/docker
+audit-log:
+  value: /var/log/audit/audit.log

--- a/cfg/cis-1.0/definitions.yaml
+++ b/cfg/cis-1.0/definitions.yaml
@@ -1430,7 +1430,7 @@ groups:
   - id: 5.22
     description: "Ensure docker exec commands are not used with privileged option
     (Scored)"
-    audit: "ausearch -k docker | grep exec | grep privileged"
+    audit: "ausearch -if $audit-log -k docker | grep exec | grep privileged"
     tests:
       test_items:
       - flag: ""
@@ -1439,13 +1439,18 @@ groups:
           value: ""
         set: true
     remediation: |
+      If audit rule for docker file not set\n
+      Add the line as below in /etc/audit/audit.rules file:\n
+      -w /usr/bin/docker -p rwxa -k docker-daemon\n
+      Then, restart the audit daemon.\n
+      service auditd restart\n
       Do not use --privileged option in docker exec command.
     scored: true
 
   - id: 5.23
     description: "Ensure docker exec commands are not used with user option
     (Scored)"
-    audit: "ausearch -k docker | grep exec | grep user"
+    audit: "ausearch -if $audit-log -k docker | grep exec | grep user"
     tests:
       test_items:
       - flag: ""
@@ -1454,6 +1459,11 @@ groups:
           value: ""
         set: true
     remediation: |
+      If audit rule for docker file not set\n
+      Add the line as below in /etc/audit/audit.rules file:\n
+      -w /usr/bin/docker -p rwxa -k docker-daemon\n
+      Then, restart the audit daemon.\n
+      service auditd restart\n
       Do not use --user option in docker exec command.
     scored: true
 

--- a/cfg/cis-1.1/config.yaml
+++ b/cfg/cis-1.1/config.yaml
@@ -5,3 +5,5 @@
 
 docker-storage:
   value: /var/lib/docker
+audit-log:
+  value: /var/log/audit/audit.log

--- a/cfg/cis-1.1/definitions.yaml
+++ b/cfg/cis-1.1/definitions.yaml
@@ -1437,7 +1437,7 @@ groups:
   - id: 5.22
     description: "Ensure docker exec commands are not used with privileged option
     (Scored)"
-    audit: "ausearch -k docker | grep exec | grep privileged"
+    audit: "ausearch -if $audit-log -k docker | grep exec | grep privileged"
     tests:
       test_items:
       - flag: ""
@@ -1446,13 +1446,18 @@ groups:
           value: ""
         set: true
     remediation: |
+      If audit rule for docker file not set\n
+      Add the line as below in /etc/audit/audit.rules file:\n
+      -w /usr/bin/docker -p rwxa -k docker-daemon\n
+      Then, restart the audit daemon.\n
+      service auditd restart\n
       Do not use --privileged option in docker exec command.
     scored: true
 
   - id: 5.23
     description: "Ensure docker exec commands are not used with user option
     (Scored)"
-    audit: "ausearch -k docker | grep exec | grep user"
+    audit: "ausearch -if $audit-log -k docker | grep exec | grep user"
     tests:
       test_items:
       - flag: ""
@@ -1461,6 +1466,11 @@ groups:
           value: ""
         set: true
     remediation: |
+      If audit rule for docker file not set\n
+      Add the line as below in /etc/audit/audit.rules file:\n
+      -w /usr/bin/docker -p rwxa -k docker-daemon\n
+      Then, restart the audit daemon.\n
+      service auditd restart\n
       Do not use --user option in docker exec command.
     scored: true
 

--- a/cfg/cis-1.2/config.yaml
+++ b/cfg/cis-1.2/config.yaml
@@ -5,3 +5,5 @@
 
 docker-storage:
   value: /var/lib/docker
+audit-log:
+  value: /var/log/audit/audit.log

--- a/cfg/cis-1.2/definitions.yaml
+++ b/cfg/cis-1.2/definitions.yaml
@@ -1525,7 +1525,7 @@ groups:
   - id: 5.22
     description: "Ensure that docker exec commands are not used with the privileged option
     (Scored)"
-    audit: "ausearch -k docker | grep exec | grep privileged"
+    audit: "ausearch -if $audit-log -k docker | grep exec | grep privileged"
     tests:
       test_items:
       - flag: ""
@@ -1534,12 +1534,17 @@ groups:
           value: ""
         set: true
     remediation: |
+      If audit rule for docker file not set\n
+      Add the line as below in /etc/audit/audit.rules file:\n
+      -w /usr/bin/docker -p rwxa -k docker-daemon\n
+      Then, restart the audit daemon.\n
+      service auditd restart\n
       You should not use the --privileged option in docker exec commands.
     scored: true
 
   - id: 5.23
     description: "Ensure that docker exec commands are not used with the user=root option (Not Scored)"
-    audit: "ausearch -k docker | grep exec | grep user"
+    audit: "ausearch -if $audit-log -k docker | grep exec | grep user"
     tests:
       test_items:
       - flag: ""
@@ -1548,6 +1553,11 @@ groups:
           value: ""
         set: true
     remediation: |
+      If audit rule for docker file not set\n
+      Add the line as below in /etc/audit/audit.rules file:\n
+      -w /usr/bin/docker -p rwxa -k docker-daemon\n
+      Then, restart the audit daemon.\n
+      service auditd restart\n
       You should not use the --user=root option in docker exec commands.
     scored: true
 

--- a/cfg/cis-1.3.1/config.yaml
+++ b/cfg/cis-1.3.1/config.yaml
@@ -8,3 +8,6 @@ docker-storage:
 
 docker-config-file:
   value: /etc/docker/daemon.json
+
+audit-log:
+  value: /var/log/audit/audit.log

--- a/cfg/cis-1.3.1/definitions.yaml
+++ b/cfg/cis-1.3.1/definitions.yaml
@@ -1553,18 +1553,23 @@ groups:
 
   - id: 5.22
     description: "Ensure that docker exec commands are not used with the privileged option (Automated)"
-    audit: "ausearch -k docker | grep exec | grep privileged"
+    audit: "ausearch -if $audit-log -k docker | grep exec | grep privileged"
     tests:
       test_items:
       - flag: "privileged"
         set: false
     remediation: |
+      If audit rule for docker file not set\n
+      Add the line as below in /etc/audit/audit.rules file:\n
+      -w /usr/bin/docker -p rwxa -k docker-daemon\n
+      Then, restart the audit daemon.\n
+      service auditd restart\n
       You should not use the --privileged option in docker exec commands.
     scored: true
 
   - id: 5.23
     description: "Ensure that docker exec commands are not used with the user=root option (Manual)"
-    audit: "ausearch -k docker | grep exec | grep user"
+    audit: "ausearch -if $audit-log -k docker | grep exec | grep user"
     tests:
       test_items:
       - flag: "user"
@@ -1573,6 +1578,11 @@ groups:
           value: "root"
         set: true
     remediation: |
+      If audit rule for docker file not set\n
+      Add the line as below in /etc/audit/audit.rules file:\n
+      -w /usr/bin/docker -p rwxa -k docker-daemon\n
+      Then, restart the audit daemon.\n
+      service auditd restart\n
       You should not use the --user=root option in docker exec commands.
     scored: true
 


### PR DESCRIPTION
default path for audit-log was not available when checks are executed by bench-common module.
Passing audit path explicitly for ausearch checks

Added remediation steps to setup audit rules so that audit log have the proper data as mentioned in the checks