### PR TITLE
modify the audit and remediation of check 1.1.4

### DIFF
--- a/cfg/cis-1.3.1/definitions.yaml
+++ b/cfg/cis-1.3.1/definitions.yaml
@@ -49,13 +49,13 @@ groups:
   
   - id: 1.1.4
     description: "Ensure auditing is configured for Docker files and directories - /run/containerd (Automated)"
-    audit: "auditctl -l | grep /run/containerd"
+    audit: "auditctl -l | grep '/run/containerd\\s'"
     tests:
       test_items:
       - flag: "/run/containerd"
         set: true
     remediation: |
-      You should add a rule for the $docker-storage directory. 
+      You should add a rule for the /run/containerd directory. 
       For example, 
       Add the line as below to the /etc/audit/audit.rules file:
       -a exit,always -F path=/run/containerd -F perm=war -k docker


### PR DESCRIPTION
update check 1.1.4

1. audit:Add space behind the dir `/run/containerd`.See #106 
2. remediation:Fix the error of dir