### PR TITLE
id:1.1.8(cis-1.3.1) was a False Alarm in detection.

### DIFF
--- a/cfg/cis-1.3.1/definitions.yaml
+++ b/cfg/cis-1.3.1/definitions.yaml
@@ -119,8 +119,8 @@ groups:
   - id: 1.1.8
     description: "Ensure auditing is configured for Docker files and directories - containerd.sock (Automated)"
     audit: |
-      test_file=$(grep 'containerd.sock' /etc/containerd/config.toml | awk -F "=" '{print $2}')
-      if test -f "$test_file"; then
+      test_file=$(grep 'containerd.sock' /etc/containerd/config.toml | awk -F "\"" '{print $2}')
+      if test -S "$test_file"; then
         auditctl -l | grep $test_file
       fi
     tests:


### PR DESCRIPTION
## Issue
#110 

## Analysis
**1. Looking at the content of the file, we found that the path of `containerd.sock` is included in double quotation marks.**
```Bash
cat /etc/containerd/config.toml
#   Copyright 2018-2022 Docker Inc.

#   Licensed under the Apache License, Version 2.0 (the "License");
#   you may not use this file except in compliance with the License.
#   You may obtain a copy of the License at

#       http://www.apache.org/licenses/LICENSE-2.0

#   Unless required by applicable law or agreed to in writing, software
#   distributed under the License is distributed on an "AS IS" BASIS,
#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
#   See the License for the specific language governing permissions and
#   limitations under the License.

disabled_plugins = ["cri"]

#root = "/var/lib/containerd"
#state = "/run/containerd"
#subreaper = true
#oom_score = 0

#[grpc]
#  address = "/run/containerd/containerd.sock"
#  uid = 0
#  gid = 0

#[debug]
#  address = "/run/containerd/debug.sock"
#  uid = 0
#  gid = 0
#  level = "info"
```
**2. Modify the `grep` command**
  
before
  ```Bash
  grep 'containerd.sock' /etc/containerd/config.toml | awk -F "=" '{print $2}'
   "/run/containerd/containerd.sock"
  ```
  after
  ```Bash
  grep 'containerd.sock' /etc/containerd/config.toml | awk -F "\"" '{print $2}'
  /run/containerd/containerd.sock
  ```
**3. In addition, containerd.sock is a socket file, so `-S` should be used to test.**
  
before
  ```Bash
  if test -f "$test_file"; then
          auditctl -l | grep $test_file
   fi
  ```
  after
  ```Bash
  if test -S "$test_file"; then
          auditctl -l | grep $test_file
   fi
  ```
## Running
```Bash
./docker-bench --check="./docker-bench --check="1.1.8"
[INFO] 20.04 CIS Docker Community Edition Benchmark
[INFO] 1.1 Linux Hosts Specific Configuration
[PASS] 1.1.8 Ensure auditing is configured for Docker files and directories - containerd.sock (Automated)

== Summary ==
1 checks PASS
0 checks FAIL
0 checks WARN
0 checks INFO
```