### PR TITLE
id:1.1.9(cis-1.3.1) was a False Alarm in detection. 

### DIFF
--- a/cfg/cis-1.3.1/definitions.yaml
+++ b/cfg/cis-1.3.1/definitions.yaml
@@ -152,7 +152,7 @@ groups:
       If the file exists, you should add a rule for it. 
       For example: 
       Add the line below to the /etc/audit/audit.rules file:
-      -w /var/run/docker.sock -k docker
+      -w $socket_file -k docker
       Then restart the audit daemon. 
       For example:
       systemctl restart auditd

--- a/cfg/cis-1.3.1/definitions.yaml
+++ b/cfg/cis-1.3.1/definitions.yaml
@@ -140,14 +140,13 @@ groups:
   - id: 1.1.9
     description: "Ensure auditing is configured for Docker files and directories - docker.socket (Automated)"
     audit: |
-      test_file=$(systemctl show -p FragmentPath docker.socket | awk -F "=" '{print $2}')
-      socket_file=$(grep ListenStream $testfile)
-      if test -f "$socket_file"; then
+      socket_file=$(grep '^ListenStream' $(systemctl show -p FragmentPath docker.socket | awk -F"=" '{print $2}')| awk -F "=" '{print $2}')
+      if test -S "$socket_file"; then
         auditctl -l | grep $socket_file
       fi
     tests:
       test_items:
-      - flag: "docker.sockest"
+      - flag: "docker.sock"
         set: true
     remediation: |
       If the file exists, you should add a rule for it. 


### PR DESCRIPTION
## Issue
#112 

## Analysis
1. Looking at the content of the `docker.socket`, We found 2 ListenStream keywords. What we need is the file path after the equal sign of the line which beginning with  `ListenStream`.
```Bash
cat /lib/systemd/system/docker.socket
[Unit]
Description=Docker Socket for the API

[Socket]
# If /var/run is not implemented as a symlink to /run, you may need to
# specify ListenStream=/var/run/docker.sock instead.
ListenStream=/run/docker.sock
SocketMode=0660
SocketUser=root
SocketGroup=docker

[Install]
WantedBy=sockets.target
```
**2. Modify the `grep` command**
  ```Bash
  grep '^ListenStream' $(systemctl show -p FragmentPath docker.socket | awk -F"=" '{print $2}')| awk -F "=" '{print $2}'
/run/docker.sock
  ```
**3. In addition, docker.sock is a socket file, so `-S` should be used to test.**
  ```Bash
      if test -S "$socket_file"; then
        auditctl -l | grep $socket_file
      fi
  ```
4. The flag is `docker.sock` instead of `docker.sockest`
## Running
```Bash
./docker-bench --check="1.1.9"
[INFO] 20.04 CIS Docker Community Edition Benchmark
[INFO] 1.1 Linux Hosts Specific Configuration
[PASS] 1.1.9 Ensure auditing is configured for Docker files and directories - docker.socket (Automated)

== Summary ==
1 checks PASS
0 checks FAIL
0 checks WARN
0 checks INFO
```